### PR TITLE
Fixes runs.using yaml validation error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,8 @@ inputs:
     description: "When specified, installs the requested version or tag of the CLI"
     required: false
 runs:
-  using: "node18"
+  using: "node16"
   main: "dist/index.js"
 branding:
-  icon: "log-in"  
+  icon: "log-in"
   color: "blue"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/action-cli-login",
-  "version": "2.2.1",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/action-cli-login",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "GitHub Action to Login to a tenant using CLI for Microsoft 365",
   "license": "MIT",
   "main": "lib/main.js",


### PR DESCRIPTION
Merging this PR will

- Fix the YAML schema validation error generated by using an incorrect value and reverts to valid `node16`